### PR TITLE
Use a single HTTP client for all requests

### DIFF
--- a/src/tests/container_stats.rs
+++ b/src/tests/container_stats.rs
@@ -1,9 +1,11 @@
 use chrono::DateTime;
 use mockito::mock;
+use reqwest::Client as HttpClient;
 use serde_json::json;
 
 #[test]
 fn no_containers() {
+  let http = HttpClient::new();
   let reply = json!({});
 
   let _stats_api = mock("GET", "/v2/stats")
@@ -13,13 +15,14 @@ fn no_containers() {
     .create();
 
   assert_eq!(
-    crate::container_stats(&mockito::server_url()).unwrap(),
+    crate::container_stats(&http, &mockito::server_url()).unwrap(),
     Vec::<crate::Stats>::new()
   );
 }
 
 #[test]
 fn extrace_container_stats() {
+  let http = HttpClient::new();
   let reply = json!({
     "ze-id": {
       "read": "2019-01-07T23:15:48.677482816Z",
@@ -51,12 +54,13 @@ fn extrace_container_stats() {
       timestamp: DateTime::parse_from_rfc3339("2019-01-07T23:15:48.677482816Z").unwrap(),
     }
   ];
-  let actual = crate::container_stats(&mockito::server_url()).unwrap();
+  let actual = crate::container_stats(&http, &mockito::server_url()).unwrap();
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn new_container_is_null() {
+  let http = HttpClient::new();
   let reply = json!({"ze-id": null});
 
   let _stats_api = mock("GET", "/v2/stats")
@@ -66,7 +70,7 @@ fn new_container_is_null() {
     .create();
 
   assert_eq!(
-    crate::container_stats(&mockito::server_url()).unwrap(),
+    crate::container_stats(&http, &mockito::server_url()).unwrap(),
     Vec::<crate::Stats>::new()
   );
 }

--- a/src/tests/task_metadata.rs
+++ b/src/tests/task_metadata.rs
@@ -1,10 +1,12 @@
 use mockito::mock;
+use reqwest::Client as HttpClient;
 use rusoto_cloudwatch::Dimension;
 use serde_json::json;
 use std::collections::HashMap;
 
 #[test]
 fn no_containers() {
+  let http = HttpClient::new();
   let reply = json!({"Containers": []});
 
   let _metadata_api = mock("GET", "/v2/metadata")
@@ -15,12 +17,13 @@ fn no_containers() {
 
   assert_eq!(
     HashMap::<String, crate::Metadata>::new(),
-    crate::task_metadata(&mockito::server_url()).unwrap()
+    crate::task_metadata(&http, &mockito::server_url()).unwrap()
   );
 }
 
 #[test]
 fn with_containers() {
+  let http = HttpClient::new();
   let reply = json!({"Containers": [
     {
       "DockerId": "ze-id",
@@ -39,7 +42,7 @@ fn with_containers() {
     .with_body(reply.to_string())
     .create();
 
-  let actual = crate::task_metadata(&mockito::server_url()).unwrap();
+  let actual = crate::task_metadata(&http, &mockito::server_url()).unwrap();
   let mut expected = HashMap::<String, crate::Metadata>::new();
   expected.insert(
     "ze-id".to_owned(),


### PR DESCRIPTION
This is significant as the simple form `reqwest::get()` seems to leak memory.

This PR also hard-codes a connection timeout of 2 sec which should be plenty to connect to a service nominally running on the same host.