### PR TITLE
Queue collected metrics in case of communications error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_cloudwatch 0.36.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.36.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_mock 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_cloudwatch 0.36.0 (git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2)",
+ "rusoto_core 0.36.0 (git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2)",
+ "rusoto_mock 0.30.0 (git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -970,10 +970,10 @@ dependencies = [
 [[package]]
 name = "rusoto_cloudwatch"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2#bfbd110e24e1ea7d71d7eac9e182fb6da6691003"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.36.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.36.0 (git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2)",
  "serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "rusoto_core"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2#bfbd110e24e1ea7d71d7eac9e182fb6da6691003"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -992,7 +992,7 @@ dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.15.0 (git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1006,7 +1006,7 @@ dependencies = [
 [[package]]
 name = "rusoto_credential"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2#bfbd110e24e1ea7d71d7eac9e182fb6da6691003"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1022,12 +1022,12 @@ dependencies = [
 [[package]]
 name = "rusoto_mock"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2#bfbd110e24e1ea7d71d7eac9e182fb6da6691003"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.36.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.36.0 (git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1683,10 +1683,10 @@ dependencies = [
 "checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ab52e462d1e15891441aeefadff68bdea005174328ce3da0a314f2ad313ec837"
-"checksum rusoto_cloudwatch 0.36.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b11f37a855b24c1fde34ad3de8d1c2b9c5094f7799ba1681918a285cd9505a9"
-"checksum rusoto_core 0.36.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18a699355ef3189e3bbf34b64ff5a31f06456b689b09d05cdb4a901dcf4406a8"
-"checksum rusoto_credential 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc8dd0f0a7e8b62f31aa23fa12fa0a7ac0e1eb52f6f4d4279d8a2ae51d8f099"
-"checksum rusoto_mock 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2543423d28b3ebd8116949d3bd80b12b952366bb46e3a55251e88a4d84e21ed5"
+"checksum rusoto_cloudwatch 0.36.0 (git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2)" = "<none>"
+"checksum rusoto_core 0.36.0 (git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2)" = "<none>"
+"checksum rusoto_credential 0.15.0 (git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2)" = "<none>"
+"checksum rusoto_mock 0.30.0 (git+https://github.com/bittrance/rusoto?branch=mock-dispatch-errors-take-2)" = "<none>"
 "checksum rustc-demangle 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "rusoto_core 0.36.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_mock 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ stderrlog = "0.4.1"
 [dev-dependencies]
 mockito = "*"
 rusoto_mock = "*"
+serde_urlencoded = "*"
 
- [profile.release]
+[profile.release]
 lto = true
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ failure = "*"
 getopts = "0.2.18"
 log = "0.4.1"
 reqwest = "0.9.5"
-rusoto_cloudwatch = "0.36.0"
-rusoto_core = "0.36.0"
+rusoto_cloudwatch = { git = "https://github.com/bittrance/rusoto", branch = "mock-dispatch-errors-take-2" }
+rusoto_core = { git = "https://github.com/bittrance/rusoto", branch = "mock-dispatch-errors-take-2" }
 serde_json = "1.0.33"
 stderrlog = "0.4.1"
 
 [dev-dependencies]
 mockito = "*"
-rusoto_mock = "*"
+rusoto_mock = { git = "https://github.com/bittrance/rusoto", branch = "mock-dispatch-errors-take-2" }
 serde_urlencoded = "*"
 
 [profile.release]

--- a/src/tests/maintain_queue.rs
+++ b/src/tests/maintain_queue.rs
@@ -1,0 +1,42 @@
+use failure::Error;
+use rusoto_cloudwatch::MetricDatum;
+use super::metric_datum;
+
+#[test]
+fn handles_empty_queue() -> Result<(), Error> {
+  let mut queue = Vec::<MetricDatum>::new();
+  crate::maintain_queue(&mut queue, 10, Box::new(|_: &Vec<MetricDatum>| Ok(0 as usize)))
+}
+
+#[test]
+fn culls_queue_according_to_closure() -> Result<(), Error> {
+  let mut queue = vec![metric_datum(), metric_datum(), metric_datum()];
+  crate::maintain_queue(&mut queue, 10, Box::new(|_: &Vec<MetricDatum>| Ok(2 as usize)))?;
+  assert_eq!(1, queue.len());
+  Ok(())
+}
+
+#[test]
+fn culls_queue_from_start() -> Result<(), Error> {
+  let mut queue = vec![metric_datum(), metric_datum(), metric_datum()];
+  queue[2].value = Some(26.0);
+  crate::maintain_queue(&mut queue, 10, Box::new(|_: &Vec<MetricDatum>| Ok(2 as usize)))?;
+  assert_eq!(Some(26.0), queue[0].value);
+  Ok(())
+}
+
+#[test]
+fn culls_queue_according_to_max_queue_size() -> Result<(), Error> {
+  let mut queue = vec![metric_datum(), metric_datum(), metric_datum()];
+  crate::maintain_queue(&mut queue, 2, Box::new(|_: &Vec<MetricDatum>| Ok(0 as usize)))?;
+  assert_eq!(2, queue.len());
+  Ok(())
+}
+
+#[test]
+fn culls_queue_according_to_minimum() -> Result<(), Error> {
+  let mut queue = vec![metric_datum(), metric_datum(), metric_datum()];
+  crate::maintain_queue(&mut queue, 2, Box::new(|_: &Vec<MetricDatum>| Ok(1 as usize)))?;
+  assert_eq!(2, queue.len());
+  Ok(())
+}

--- a/src/tests/metrics_from_stats.rs
+++ b/src/tests/metrics_from_stats.rs
@@ -2,19 +2,22 @@ use chrono::DateTime;
 use rusoto_cloudwatch::{Dimension, MetricDatum};
 use std::collections::HashMap;
 
+fn stats() -> crate::Stats {
+  crate::Stats {
+    container_id: "ze-id".to_owned(),
+    metrics: vec![crate::Metric {
+      name: "max_usage".to_owned(),
+      unit: "Bytes".to_owned(),
+      value: 0.25
+    }],
+    timestamp: DateTime::parse_from_rfc3339("2019-01-07T23:15:48.677482816Z").unwrap(),
+  }
+}
+
 #[test]
 fn stats_to_cw_metrics() {
-  let stats = vec![
-    crate::Stats {
-      container_id: "ze-id".to_owned(),
-      metrics: vec![crate::Metric {
-        name: "max_usage".to_owned(),
-        unit: "Bytes".to_owned(),
-        value: 0.25
-      }],
-      timestamp: DateTime::parse_from_rfc3339("2019-01-07T23:15:48.677482816Z").unwrap(),
-    }
-  ];
+  let mut metrics = Vec::<MetricDatum>::new();
+  let stats = vec![stats()];
   let mut metadata = HashMap::<String, crate::Metadata>::new();
   metadata.insert(
     "ze-id".to_owned(),
@@ -44,22 +47,15 @@ fn stats_to_cw_metrics() {
       ..Default::default()
     }
   ];
-  assert_eq!(expected, crate::metrics_from_stats(stats, &metadata));
+  crate::metrics_from_stats(&mut metrics, stats, &metadata);
+  assert_eq!(expected, metrics);
 }
 
 #[test]
 fn container_is_unknown() {
-  let stats = vec![
-    crate::Stats {
-      container_id: "ze-id".to_owned(),
-      metrics: vec![crate::Metric {
-        name: "max_usage".to_owned(),
-        unit: "Bytes".to_owned(),
-        value: 0.25
-      }],
-      timestamp: DateTime::parse_from_rfc3339("2019-01-07T23:15:48.677482816Z").unwrap(),
-    }
-  ];
+  let mut metrics = Vec::<MetricDatum>::new();
+  let stats = vec![stats()];
   let metadata = HashMap::<String, crate::Metadata>::new();
-  assert_eq!(Vec::<MetricDatum>::new(), crate::metrics_from_stats(stats, &metadata));
+  crate::metrics_from_stats(&mut metrics, stats, &metadata);
+  assert_eq!(Vec::<MetricDatum>::new(), metrics);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,7 +2,21 @@ extern crate rusoto_mock;
 extern crate serde_urlencoded;
 
 mod container_stats;
+mod maintain_queue;
 mod metrics_from_stats;
 mod parse_args;
 mod report_to_cloudwatch;
 mod task_metadata;
+
+use rusoto_cloudwatch::{Dimension, MetricDatum};
+
+fn metric_datum() -> MetricDatum {
+  MetricDatum {
+    dimensions: Some(vec![Dimension { name: "container".to_owned(), value: "ze-id".to_owned() }]),
+    metric_name: "max_usage".to_owned(),
+    timestamp: Some("ze-time".to_owned()),
+    unit: Some("Bytes".to_owned()),
+    value: Some(25.0),
+    ..Default::default()
+  }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,5 @@
 extern crate rusoto_mock;
+extern crate serde_urlencoded;
 
 mod container_stats;
 mod metrics_from_stats;

--- a/src/tests/report_to_cloudwatch.rs
+++ b/src/tests/report_to_cloudwatch.rs
@@ -1,4 +1,4 @@
-use rusoto_cloudwatch::{CloudWatchClient, Dimension, MetricDatum};
+use rusoto_cloudwatch::CloudWatchClient;
 use rusoto_core::HttpDispatchError;
 use rusoto_core::param::Params;
 use rusoto_core::signature::{SignedRequest, SignedRequestPayload};
@@ -6,6 +6,7 @@ use rusoto_mock::{MockCredentialsProvider, MockRequestDispatcher};
 use serde_urlencoded;
 use std::iter::repeat;
 use std::sync::{Arc, Mutex};
+use super::metric_datum;
 
 fn client_with_http_status(status: u16) -> CloudWatchClient {
   CloudWatchClient::new_with(
@@ -28,17 +29,6 @@ fn client_with_checker<F>(checker: F) -> CloudWatchClient where F: Fn(Params) + 
     MockCredentialsProvider,
     Default::default()
   )
-}
-
-fn metric_datum() -> MetricDatum {
-  MetricDatum {
-    dimensions: Some(vec![Dimension { name: "container".to_owned(), value: "ze-id".to_owned() }]),
-    metric_name: "max_usage".to_owned(),
-    timestamp: Some("ze-time".to_owned()),
-    unit: Some("Bytes".to_owned()),
-    value: Some(25.0),
-    ..Default::default()
-  }
 }
 
 #[test]

--- a/src/tests/report_to_cloudwatch.rs
+++ b/src/tests/report_to_cloudwatch.rs
@@ -1,5 +1,76 @@
 use rusoto_cloudwatch::{CloudWatchClient, Dimension, MetricDatum};
+use rusoto_core::param::Params;
+use rusoto_core::signature::{SignedRequest, SignedRequestPayload};
 use rusoto_mock::{MockCredentialsProvider, MockRequestDispatcher};
+use serde_urlencoded;
+use std::iter::repeat;
+use std::sync::{Arc, Mutex};
+
+fn client_with_http_status(status: u16) -> CloudWatchClient {
+  CloudWatchClient::new_with(
+    MockRequestDispatcher::with_status(status),
+    MockCredentialsProvider,
+    Default::default()
+  )
+}
+
+fn client_with_checker<F>(checker: F) -> CloudWatchClient where F: Fn(Params) + Send + Sync + 'static {
+  CloudWatchClient::new_with(
+    MockRequestDispatcher::with_status(200).with_request_checker(move |req: &SignedRequest|
+      if let Some(SignedRequestPayload::Buffer(ref buffer)) = req.payload {
+        let params: Params = serde_urlencoded::from_bytes(buffer).unwrap();
+        checker(params);
+      } else {
+        panic!("Unexpected request.payload: {:?}", req.payload);
+      }
+    ),
+    MockCredentialsProvider,
+    Default::default()
+  )
+}
+
+fn metric_datum() -> MetricDatum {
+  MetricDatum {
+    dimensions: Some(vec![Dimension { name: "container".to_owned(), value: "ze-id".to_owned() }]),
+    metric_name: "max_usage".to_owned(),
+    timestamp: Some("ze-time".to_owned()),
+    unit: Some("Bytes".to_owned()),
+    value: Some(25.0),
+    ..Default::default()
+  }
+}
+
+#[test]
+fn posts_metric_data_to_cloudwatch() {
+  let cw = client_with_checker(|params: Params| {
+    assert_eq!(params.get("Namespace"), Some(&Some("testing".to_owned())));
+    assert_eq!(params.get("MetricData.member.1.Value"), Some(&Some("25".to_owned())));
+  });
+  let mut data = vec![metric_datum()];
+  crate::report_to_cloudwatch(&cw, "testing", &mut data).unwrap();
+}
+
+#[test]
+fn sends_batches_of_20_metrics() {
+  let count = Arc::new(Mutex::new(0));
+  let copy = count.clone();
+  let cw = client_with_checker(move |params: Params| {
+    assert_eq!(params.get("Namespace"), Some(&Some("testing".to_owned())));
+    assert_eq!(params.get("MetricData.member.20.Value"), Some(&Some("25".to_owned())));
+    *count.lock().unwrap() += 1;
+  });
+  let mut data = repeat(metric_datum()).take(40).collect();
+  crate::report_to_cloudwatch(&cw, "testing", &mut data).unwrap();
+  assert_eq!(2, *copy.lock().unwrap());
+}
+
+#[test]
+fn clears_queue_on_success() {
+  let cw = client_with_http_status(200);
+  let mut data = vec![metric_datum(), metric_datum()];
+  crate::report_to_cloudwatch(&cw, "testing", &mut data).unwrap();
+  assert_eq!(0, data.len());
+}
 
 #[test]
 fn cloudwatch_server_side_error_is_readable() {
@@ -17,17 +88,8 @@ fn cloudwatch_server_side_error_is_readable() {
     MockCredentialsProvider,
     Default::default()
   );
-  let data = vec![
-    MetricDatum {
-      dimensions: Some(vec![Dimension { name: "".to_owned(), value: "".to_owned() }]),
-      metric_name: "max_usage".to_owned(),
-      timestamp: Some("".to_owned()),
-      unit: Some("Bytes".to_owned()),
-      value: Some(25.0),
-      ..Default::default()
-    }
-  ];
-  match crate::report_to_cloudwatch(&cw, "testing", data) {
+  let mut data = vec![metric_datum()];
+  match crate::report_to_cloudwatch(&cw, "testing", &mut data) {
     Ok(_) => panic!("Expected failed request to return err"),
     Err(msg) => assert!(format!("{}", msg).contains("foobar is not authorized")),
   };


### PR DESCRIPTION
This PR updates the main run loop to maintain a queue of metrics to `put-metric-data`. Each pass, we try to deliver batches of 20 until there is an intermittent failure, at which point we stop and wait for the next iteration. Should this fill the queue, old items are pushed out and the latest N (default 100) are retained.